### PR TITLE
fix: try to start remote tunnel for each connection

### DIFF
--- a/snova/mux/mux_client.h
+++ b/snova/mux/mux_client.h
@@ -47,7 +47,7 @@ class MuxClient {
                                         const std::string& cipher_key);
 
  private:
-  asio::awaitable<std::error_code> NewConnection(uint32_t idx, bool try_open_tunnel);
+  asio::awaitable<std::error_code> NewConnection(uint32_t idx);
   asio::awaitable<void> CheckConnections();
   MuxConnectionType conn_type_ = MUX_EXIT_CONN;
   MuxSessionPtr remote_session_;


### PR DESCRIPTION
- there is a idle timer to close the connection if it's not active 1800s
- while the remote tunnel server only start when first client connection connected;
- the entry server would close the tunnel server when all connection closed;
- this fix would try to start tunnel for each connection not just the first client connection